### PR TITLE
add transformIgnorePatterns for js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,5 +17,6 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
+  transformIgnorePatterns: ['^.+\\.js$'],
   verbose: true,
 }


### PR DESCRIPTION
Hi! Thanks so much @jeffrafter for the tutorial, it's really quality content.

I ran into an issue where `jest` was trying to import the `js` files from `build` rather than the `ts` files. This adds `^.+\\.js$` to `transformIgnorePatterns` in `jest.config.js` to prevent that.